### PR TITLE
Update puppet to new code locations at Github.

### DIFF
--- a/puppet/manifests/site.pp
+++ b/puppet/manifests/site.pp
@@ -15,7 +15,7 @@ class { 'aegee_ldap':
 # Load OMS-core
 class { 'aegee_oms_core':
   root_path  => '/srv/oms-core',
-  git_source => 'https://bitbucket.org/aegeeitc/oms-core.git',
+  git_source => 'https://github.com/AEGEE/oms-core.git',
   require    => Openldap::Server::Database['o=aegee,c=eu'],
 }
 
@@ -31,7 +31,7 @@ file { [ '/var/www', '/var/www/html', '/var/www/html/oms-modules' ]:
 vcsrepo { '/var/www/html/oms-modules':
   ensure   => present,
   provider => git,
-  source   => 'https://bitbucket.org/aegeeitc/oms-poc-modules.git',
+  source   => 'https://github.com/AEGEE/oms-poc-modules.git',
 }
 ->
 composer::exec { 'oms-modules-install':


### PR DESCRIPTION
Puppet does not seem to be able to change the URL of the remotes of the repositories it deploys. You either have to reset them by hand by modifying the respective .git/config files, delete the repositories (at your own risk), or set up a new virtual machine.