### PR TITLE
install mongodb from shell script instead of from puppet

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,7 @@ Vagrant.configure(2) do |config|
   #Profiles module port (generic nodejs app)
   config.vm.network "forwarded_port", guest: 8081, host: 8801
 
+
   
 
   #Sharing the content of the VM directly so we can work from the host
@@ -35,6 +36,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provision :shell, :path => "scripts/upgrade_puppet.sh"
   config.vm.provision :shell, :path => "scripts/empty_folder.sh"
+  config.vm.provision :shell, :path => "scripts/install_mongo.sh"
 
   config.vm.provision :puppet do |puppet|
     puppet.manifests_path = 'puppet/manifests'

--- a/puppet/manifests/site.pp
+++ b/puppet/manifests/site.pp
@@ -55,18 +55,18 @@ aegee_ldap { 'aegee_ldap':
 }
 
 #Add mongodb backend
-class { 'mongodb':
-  package_name  => 'mongodb-org',
-  logdir       => '/var/log/mongodb/',
-  # only debian like distros
-  old_servicename => 'mongod'
-}
-mongodb::mongod {'my_mongod_instance1':
-    mongod_instance    => 'mongodb1',
-    mongod_add_options => ['slowms = 50'],
-    mongod_port => 27018,
-    require => Class['mongodb'];
-}
+#class { 'mongodb':
+#  package_name  => 'mongodb-org',
+#  logdir       => '/var/log/mongodb/',
+#  # only debian like distros
+#  old_servicename => 'mongod'
+#}
+#mongodb::mongod {'my_mongod_instance1':
+#    mongod_instance    => 'mongodb1',
+#    mongod_add_options => ['slowms = 50'],
+#    mongod_port => 27018,
+#    require => Class['mongodb'];
+#}
 # DBs and users will be set by the application
 
 #Add postgresql backend

--- a/scripts/install_mongo.sh
+++ b/scripts/install_mongo.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#This is a hack because puppet modules are SHITE
+#Follows tutorial at https://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/
+
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
+echo "deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list
+sudo apt-get update && sudo apt-get install -y mongodb-org

--- a/scripts/updateschema.sh
+++ b/scripts/updateschema.sh
@@ -1,2 +1,3 @@
 sudo rm /var/opt/aegee/testdata/.dataimported
+sudo apt-get purge slapd
 sudo puppet apply --modulepath=/vagrant/puppet/modules /vagrant/scripts/updateschema.pp


### PR DESCRIPTION
The VM needs MongoDB for the scheduled tasks to work. Puppet doesn't want to work so I have to make do